### PR TITLE
Update bootstrap-better-nav.js

### DIFF
--- a/dist/bootstrap-better-nav.js
+++ b/dist/bootstrap-better-nav.js
@@ -53,7 +53,7 @@ $(function() {
 
     // Hide the menu when the overlay element is clicked.
     
-    overlay.on('click', function(e) {
+    sideMenu.on('click', function(e) {
         slideOut();
     });
 


### PR DESCRIPTION
I think the desired behavior when the user selects a nav item from the sidemenu is to go to the desired href, then to slide out (close) the sidemenu.  That does not happen as it is now.  But, with the change I have made it works.

The same/similar change can be made to the min version (change d.on to o.on)